### PR TITLE
✨ Add TimeEntryViewModel

### DIFF
--- a/timer/src/main/java/com/toggl/timer/log/domain/TimeEntryViewModel.kt
+++ b/timer/src/main/java/com/toggl/timer/log/domain/TimeEntryViewModel.kt
@@ -24,3 +24,12 @@ data class DayHeaderViewModel(
     val dayTitle: String,
     val totalDuration: Duration
 ) : TimeEntryViewModel()
+
+data class TimeEntryGroupViewModel(
+    val timeEntryIds: List<Long>,
+    val isExpanded: Boolean,
+    val description: String,
+    val duration: Duration,
+    val project: ProjectViewModel?,
+    val billable: Boolean
+) : TimeEntryViewModel()


### PR DESCRIPTION
### Summary
This adds one more ViewModel as a part of a discriminated union that represents the possible states of the TimeEntryViewModel.

### Technical considerations
Basically `FlatTimeEntryItem` with multiple ids and `isExpanded` boolean. I also left out `startTime` as I'm not sure we ever use it for groups?

### Why is it done like this and not some other way?
Another way to represent this model would be to simply include list of timeEntries and all properties like `description` or `duration` would be computed. This solves the problem with possible inconsistencies but does put some logic inside of our models 🤷‍♂️ 
Or we could keep the implementation from this PR change the constructor to accepts a list of time entries as the only parameter and model would then initialize all of its properties based on the given TE list. This logic could be moved to a companion or something... 

### Relationships

Closes  #21

## Reviewing

### Pointers
Checkout the naming situation and consider other options from **Why is it done like this and not some other way?** or suggest something else

## Merge permissions
Anyone